### PR TITLE
Fix for changes to macro syntax in latest Rust

### DIFF
--- a/lib.rs
+++ b/lib.rs
@@ -45,14 +45,14 @@ pub fn compare_iter<T, L: Iterator<T>, R: Iterator<T>>(left: L, right: R,
             l = left.next();
             ll = l.as_ref().and_then(|v| to_digit(v));
         })
-    )
+    );
 
     macro_rules! read_right(
         () => ({
             r = right.next();
             rr = r.as_ref().and_then(|v| to_digit(v));
         })
-    )
+    );
 
     macro_rules! return_unless_equal(
         ($ord:expr) => (
@@ -61,7 +61,7 @@ pub fn compare_iter<T, L: Iterator<T>, R: Iterator<T>>(left: L, right: R,
                 lastcmp => return lastcmp,
             }
         )
-    )
+    );
 
     read_left!();
     read_right!();


### PR DESCRIPTION
Changes to the way macros are parsed makes the compiler complain now: https://github.com/rust-lang/rust/pull/19984

I just added some semicolons to get it to work.
