### PR TITLE
Lowercasing now returns an Iterator

### DIFF
--- a/lib.rs
+++ b/lib.rs
@@ -144,9 +144,13 @@ pub fn compare(left: &str, right: &str) -> Ordering {
 pub fn compare_ignore_case(left: &str, right: &str) -> Ordering {
     // XXX what we really want is a case folding!
     // Unicode case folding can be done iteratively, but currently we don't have them in stdlib.
-    compare_iter(left.chars(), right.chars(),
+
+    let left_iter  =  left.chars().flat_map(|c| c.to_lowercase());
+    let right_iter = right.chars().flat_map(|c| c.to_lowercase());
+
+    compare_iter(left_iter, right_iter,
                  |&c| c.is_whitespace(),
-                 |&l, &r| l.to_lowercase().cmp(&r.to_lowercase()),
+                 |&l, &r| l.cmp(&r),
                  |&c| c.to_digit(10).map(|v| v as isize))
 }
 


### PR DESCRIPTION
The `to_lowercase()` method on char now returns an Iterator, for the times when different-cased letters are actually multiple characters long. So adjust the iterators in the `compare_ignore_case` function to scan along these flattened lowercase strings.

See https://github.com/rust-lang/rust/commit/0f6a0b58f9dbc3a741abd898f2d06a8ba78a938d for the changes that caused this.