### PR TITLE
Use proper case-folding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,6 @@ keywords = ["sort", "order", "natural"]
 readme = "README.md"
 license = "MIT"
 
-[lib]
-name = "natord"
-path = "lib.rs"
+[dependencies]
+caseless = "0.1.3"
+unicode-normalization = "0.1.5"


### PR DESCRIPTION
Instead of using `to_lowercase`, this does proper Unicode normalisation + case-folding, which works for more languages. This does up the amount of dependencies required, but I think that it's very reasonable for a crate like this to have proper Unicode support.